### PR TITLE
Update contrast for highlighted line in table

### DIFF
--- a/skin.yml
+++ b/skin.yml
@@ -12,6 +12,7 @@ pink: &pink "#e69AF7"
 blue: &blue "#7AA2F7"
 red: &red "#F7768E"
 white: &white "#C0CAF5"
+highlight: &highlight "#000CAD"
 
 k9s:
   # General K9s styles
@@ -83,7 +84,7 @@ k9s:
     table:
       fgColor: *foreground
       bgColor: default
-      cursorFgColor: *white
+      cursorFgColor: *highlight
       cursorBgColor: *background
       markColor: *pink
       # Header row styles.


### PR DESCRIPTION
I love the theme and I start using it but I notices a little contrast in the hightailed line that was making the text hardly readable for me.

I did some experiment on https://webaim.org/resources/contrastchecker/ and found a combination of colours I liked.

![Screenshot 2025-01-22 at 09 37 30](https://github.com/user-attachments/assets/791dafc4-07e7-41ad-b3c0-6dd73dc9e3be)

I applied the changes in the pr and I send those as suggestions for your repo too. Here are the screenshots of the introduced change.

Before: 
<img width="569" alt="Screenshot 2025-01-22 at 09 45 09" src="https://github.com/user-attachments/assets/729684bc-8c26-4dd0-85a6-5ea0c7a15cb3" />

After:
<img width="570" alt="Screenshot 2025-01-22 at 09 44 38" src="https://github.com/user-attachments/assets/f71e6d0e-9c46-4439-bd18-17844adb58f3" />

I know your settings are more inline with the original theme (that I'm also using in terminal and nvim setup) but in the K9s case was giving me more hard time 😁

Thank you for the great work on this skin! 🍻